### PR TITLE
Add configurable path module

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ You can run the training process using:
 ```bash
 python train_hd_ssl.py --initialize-model --training-mode --run-suffix "experiment_name"
 ```
+
+### Customizing Data Paths
+Default directories for raw data, processed data, model outputs and checkpoints
+are defined in `paths.py`. These values point to `/content/...` so the code runs
+out of the box in Google Colab. To override any of the locations on your local
+machine, either edit `paths.py` or set the environment variables
+`RAW_DATA_AND_LABELS_DIR`, `PROCESSED_DATA_DIR`, `OUTPUT_DIR` and
+`CHECKPOINT_PATH` before running the scripts:
+
+```bash
+export RAW_DATA_AND_LABELS_DIR=/path/to/raw
+export PROCESSED_DATA_DIR=/path/to/processed
+export OUTPUT_DIR=/path/to/outputs
+export CHECKPOINT_PATH=/path/to/checkpoint.pt
+python train_hd_ssl.py
+```
 Data is available in:
 https://zenodo.org/records/14384260
 

--- a/daily_living_results_eval.py
+++ b/daily_living_results_eval.py
@@ -1,8 +1,8 @@
 import ssl_boosting
 import numpy as np
 import os
-import os
 from datetime import datetime, timedelta
+from paths import OUTPUT_DIR, PROCESSED_DATA_DIR
 import ipdb
 import matplotlib.pyplot as plt
 import plotly.express as px
@@ -52,11 +52,18 @@ def main(COHORT = 'hc', model_type = 'segmentation', dataset_hd = 'pace'):
 
     GAIT_ONLY = True
     gait_only_prefix = "_gait_only" if GAIT_ONLY else ""
-    OUTPUT_DIR = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files'
-    PLOT_OUTPUT_DIR = f'/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/results_visualization/boosting/{OUT_PREFIX}_per_day_{model_type}_{COHORT}'
+    PLOT_OUTPUT_DIR = os.path.join(
+        OUTPUT_DIR,
+        f'results_visualization/boosting/{OUT_PREFIX}_per_day_{model_type}_{COHORT}'
+    )
     if not os.path.exists(PLOT_OUTPUT_DIR):
         os.makedirs(PLOT_OUTPUT_DIR)
-    input_file = np.load(f'/mlwell-data2/dafna/daily_living_data_array/data_ready/windows_input_to_multiclass_model_{COHORT}_only_{INP_PREFIX}.npz')
+    input_file = np.load(
+        os.path.join(
+            PROCESSED_DATA_DIR,
+            f'windows_input_to_multiclass_model_{COHORT}_only_{INP_PREFIX}.npz'
+        )
+    )
     output_file = np.load(os.path.join(OUTPUT_DIR, f'multiclass_separated_labels_predictions_and_logits_with_true_labels_and_subjects_{COHORT}_only_boosting_{OUT_PREFIX}'+gait_only_prefix+'.npz'),allow_pickle=True)
 
 
@@ -109,10 +116,12 @@ def main(COHORT = 'hc', model_type = 'segmentation', dataset_hd = 'pace'):
     gait_predictions_logits_all_folds = output_file['gait_predictions_logits_all_folds']
 
     patient_times = {}
+    base_dir = os.path.dirname(__file__)
     if dataset_hd == 'pace':
-        time_until_end = calculate_seconds_until_end_of_day(f'/home/dafnas1/my_repo/hd_gait_detection_with_SSL/{dataset_hd.upper()}_start_times.txt') 
+        start_file = os.path.join(base_dir, f'{dataset_hd.upper()}_start_times.txt')
     else:
-        time_until_end = calculate_seconds_until_end_of_day(f'/home/dafnas1/my_repo/hd_gait_detection_with_SSL/{COHORT.upper()}_start_times.txt')
+        start_file = os.path.join(base_dir, f'{COHORT.upper()}_start_times.txt')
+    time_until_end = calculate_seconds_until_end_of_day(start_file)
     # with open('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/start_times.txt', 'r') as file:
     #     lines = file.readlines()
     walking_precent = open(os.path.join(PLOT_OUTPUT_DIR, 'walking_precent.csv'), 'w')

--- a/evaluation_func.py
+++ b/evaluation_func.py
@@ -1,3 +1,5 @@
+from paths import OUTPUT_DIR
+
 def confusion_matrix(labels, predictions, prefix1='', prefix2='', output_dir=None):
     if len(labels) == 0:
         return
@@ -190,19 +192,19 @@ def _update_dict_res(res_dict, key, labels, prob):
                      }
 
     def update_scores_file(scores_file, new_config_name, new_scores):
-    try:
-        # Load existing scores from file
-        with open(scores_file, 'r') as f:
-            existing_scores = json.load(f)
-    except FileNotFoundError:
-        existing_scores = {}
+        try:
+            # Load existing scores from file
+            with open(scores_file, 'r') as f:
+                existing_scores = json.load(f)
+        except FileNotFoundError:
+            existing_scores = {}
 
-    # Update existing scores with new configuration
-    existing_scores[new_config_name] = new_scores
+        # Update existing scores with new configuration
+        existing_scores[new_config_name] = new_scores
 
-    # Save updated scores back to the file
-    with open(scores_file, 'w') as f:
-        json.dump(existing_scores, f, indent=4)
+        # Save updated scores back to the file
+        with open(scores_file, 'w') as f:
+            json.dump(existing_scores, f, indent=4)
 
 def find_optimal_threshold_roc(pred_probs, true_labels,subject_name,plot_roc=False,output_dir=None):
     fpr, tpr, thresholds = roc_curve(true_labels, pred_probs)
@@ -230,10 +232,13 @@ def find_optimal_threshold_roc(pred_probs, true_labels,subject_name,plot_roc=Fal
 def plot_curves(labels, probs):
     fpr, tpr, _ = metrics.roc_curve(labels, probs)
     precision, recall, _ = metrics.precision_recall_curve(labels, probs)
-    np.save(os.path.join('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves',f'fpr_{OUT_PREFIX}.npy'),fpr)
-    np.save(os.path.join('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves',f'tpr_{OUT_PREFIX}.npy'),tpr)
-    np.save(os.path.join('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves',f'precision_{OUT_PREFIX}.npy'),precision)
-    np.save(os.path.join('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves',f'recall_{OUT_PREFIX}.npy'),recall)
+    curves_dir = os.path.join(OUTPUT_DIR, 'final_graphs/pd_curves')
+    if not os.path.exists(curves_dir):
+        os.makedirs(curves_dir)
+    np.save(os.path.join(curves_dir, f'fpr_{OUT_PREFIX}.npy'), fpr)
+    np.save(os.path.join(curves_dir, f'tpr_{OUT_PREFIX}.npy'), tpr)
+    np.save(os.path.join(curves_dir, f'precision_{OUT_PREFIX}.npy'), precision)
+    np.save(os.path.join(curves_dir, f'recall_{OUT_PREFIX}.npy'), recall)
 
     ipdb.set_trace()
     plt.figure()

--- a/generate_scatter_compare_hd_hc.py
+++ b/generate_scatter_compare_hd_hc.py
@@ -3,6 +3,8 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 import ipdb
 import numpy as np
+import os
+from paths import OUTPUT_DIR
 from scipy import stats
 import os
 
@@ -64,13 +66,15 @@ def correlation_plot(x, y, filename):
     plt.close()
 def main():
     # Parse arguments
-    seg_hc_csv_file_name = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/results_visualization/boosting/daily_living_seg_triple_wind_no_std_per_day_segmentation_hc/walking_precent.csv'
-    seg_hd_csv_file_name = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/results_visualization/boosting/daily_living_seg_triple_wind_no_std_per_day_segmentation_hd/walking_precent.csv'
-    class_hc_csv_file_name = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/results_visualization/boosting/daily_living_classification_no_std_per_day_classification_hc/walking_precent.csv'
-    class_hd_csv_file_name = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/results_visualization/boosting/daily_living_classification_no_std_per_day_classification_hd/walking_precent.csv'
-    output_file_name = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/daily_living/compare_methods_HD_and_HC_scatter.png'
-    tms_walking_time_corr_file_name = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/daily_living/tms_walking_time_corr.png'
-    chorea_box_plot_walking_time_corr_file_name = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/daily_living/chorea_box_plot_walking_time_corr_sns.png'
+    base_boost = os.path.join(OUTPUT_DIR, 'results_visualization/boosting')
+    seg_hc_csv_file_name = os.path.join(base_boost, 'daily_living_seg_triple_wind_no_std_per_day_segmentation_hc/walking_precent.csv')
+    seg_hd_csv_file_name = os.path.join(base_boost, 'daily_living_seg_triple_wind_no_std_per_day_segmentation_hd/walking_precent.csv')
+    class_hc_csv_file_name = os.path.join(base_boost, 'daily_living_classification_no_std_per_day_classification_hc/walking_precent.csv')
+    class_hd_csv_file_name = os.path.join(base_boost, 'daily_living_classification_no_std_per_day_classification_hd/walking_precent.csv')
+    daily_graphs = os.path.join(OUTPUT_DIR, 'final_graphs/daily_living')
+    output_file_name = os.path.join(daily_graphs, 'compare_methods_HD_and_HC_scatter.png')
+    tms_walking_time_corr_file_name = os.path.join(daily_graphs, 'tms_walking_time_corr.png')
+    chorea_box_plot_walking_time_corr_file_name = os.path.join(daily_graphs, 'chorea_box_plot_walking_time_corr_sns.png')
     tms = np.array([43,	-1,	30,	60,	44,	63,	62,	12,	32,	31,	34,	55,	10,	10,	33,	41,	68,	45,	42,	52])
     chorea_arm_score = np.array([2,3,2,3,2,3,2,1,2,1,2,2,0,0,2,1,3,3,3,3])
     valid_tms_indices = np.where(tms>0)[0].astype(int)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 import preprocessing
 import numpy as np
 import os
-from models_new import GaitDetectorSSL,GaitChoreaDetectorSSL
+from models_new import GaitDetectorSSL, GaitChoreaDetectorSSL
+from paths import RAW_DATA_AND_LABELS_DIR, PROCESSED_DATA_DIR, OUTPUT_DIR
 import torch
 from sklearn import metrics
 from scipy.special import softmax
@@ -80,14 +81,10 @@ args = parser.parse_args()
 
 
 VISUALIZE_ACC_VS_PRED_WIN = False
-RAW_DATA_AND_LABELS_DIR = '/home/dafnas1/datasets/hd_dataset/lab_geneactive/synced_labeled_data_walking_non_walking'
-#RAW_DATA_AND_LABELS_DIR = '/mlwell-data2/dafna/daily_living_data_array/HC'
-#RAW_DATA_AND_LABELS_DIR = '/mlwell-data2/dafna/PD_data_and_labels/Data'
-#PD_RAW_LABELS_DIR = '/mlwell-data2/dafna/PD_data_and_labels/labels'
-#RAW_DATA_AND_LABELS_DIR = '/mlwell-data2/dafna/daily_living_data_array/PACE'
-PROCESSED_DATA_DIR ='/mlwell-data2/dafna/daily_living_data_array/data_ready'
-OUTPUT_DIR = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs'
-VIZUALIZE_DIR = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/results_visualization/multiclass_hd_only/multiclass_separated_labels'
+VIZUALIZE_DIR = os.path.join(
+    OUTPUT_DIR,
+    'results_visualization/multiclass_hd_only/multiclass_separated_labels'
+)
 if args.cohort == 'pd_owly':
     SRC_SAMPLE_RATE = int(25) #hz
 else:

--- a/model_outputs/final_graphs/json_visualization.py
+++ b/model_outputs/final_graphs/json_visualization.py
@@ -3,11 +3,12 @@ import numpy as np
 import json
 import os
 import ipdb
+from paths import OUTPUT_DIR
 
 plt.rcParams.update({'font.size': 12})
 
-JSON_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/scores.json'
-OUT_PATH = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs'
+JSON_FILE = os.path.join(OUTPUT_DIR, 'scores.json')
+OUT_PATH = os.path.join(OUTPUT_DIR, 'final_graphs')
 NUM_CHOREA_CLASS = 5
 
 def main():

--- a/model_outputs/final_graphs/pd_curves/combine_curves.py
+++ b/model_outputs/final_graphs/pd_curves/combine_curves.py
@@ -1,28 +1,31 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.metrics import auc
+import os
+from paths import OUTPUT_DIR
 
 # Load data for model 1
-precision_classification_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/precision_classification_with_std_rm_with_fine_tuning.npy')
-recall_classification_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/recall_classification_with_std_rm_with_fine_tuning.npy')
-fpr_classification_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/fpr_classification_with_std_rm_with_fine_tuning.npy')
-tpr_classification_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/tpr_classification_with_std_rm_with_fine_tuning.npy')
+curves_dir = os.path.join(OUTPUT_DIR, 'final_graphs/pd_curves')
+precision_classification_ft = np.load(os.path.join(curves_dir, 'precision_classification_with_std_rm_with_fine_tuning.npy'))
+recall_classification_ft = np.load(os.path.join(curves_dir, 'recall_classification_with_std_rm_with_fine_tuning.npy'))
+fpr_classification_ft = np.load(os.path.join(curves_dir, 'fpr_classification_with_std_rm_with_fine_tuning.npy'))
+tpr_classification_ft = np.load(os.path.join(curves_dir, 'tpr_classification_with_std_rm_with_fine_tuning.npy'))
 
-precision_classification_no_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/precision_classification_with_std_rm.npy')
-recall_classification_no_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/recall_classification_with_std_rm.npy')
-fpr_classification_no_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/fpr_classification_with_std_rm.npy')
-tpr_classification_no_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/tpr_classification_with_std_rm.npy')
+precision_classification_no_ft = np.load(os.path.join(curves_dir, 'precision_classification_with_std_rm.npy'))
+recall_classification_no_ft = np.load(os.path.join(curves_dir, 'recall_classification_with_std_rm.npy'))
+fpr_classification_no_ft = np.load(os.path.join(curves_dir, 'fpr_classification_with_std_rm.npy'))
+tpr_classification_no_ft = np.load(os.path.join(curves_dir, 'tpr_classification_with_std_rm.npy'))
 
 # Load data for model 2
-precision_segmentation_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/precision_segmentation_triple_wind_with_std_rm_with_fine_tuning.npy')
-recall_segmentation_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/recall_segmentation_triple_wind_with_std_rm_with_fine_tuning.npy')
-fpr_segmentation_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/fpr_segmentation_triple_wind_with_std_rm_with_fine_tuning.npy')
-tpr_segmentation_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/tpr_segmentation_triple_wind_with_std_rm_with_fine_tuning.npy')
+precision_segmentation_ft = np.load(os.path.join(curves_dir, 'precision_segmentation_triple_wind_with_std_rm_with_fine_tuning.npy'))
+recall_segmentation_ft = np.load(os.path.join(curves_dir, 'recall_segmentation_triple_wind_with_std_rm_with_fine_tuning.npy'))
+fpr_segmentation_ft = np.load(os.path.join(curves_dir, 'fpr_segmentation_triple_wind_with_std_rm_with_fine_tuning.npy'))
+tpr_segmentation_ft = np.load(os.path.join(curves_dir, 'tpr_segmentation_triple_wind_with_std_rm_with_fine_tuning.npy'))
 
-precision_segmentation_no_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/precision_segmentation_triple_wind_with_std_rm.npy')
-recall_segmentation_no_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/recall_segmentation_triple_wind_with_std_rm.npy')
-fpr_segmentation_no_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/fpr_segmentation_triple_wind_with_std_rm.npy')
-tpr_segmentation_no_ft = np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves/tpr_segmentation_triple_wind_with_std_rm.npy')
+precision_segmentation_no_ft = np.load(os.path.join(curves_dir, 'precision_segmentation_triple_wind_with_std_rm.npy'))
+recall_segmentation_no_ft = np.load(os.path.join(curves_dir, 'recall_segmentation_triple_wind_with_std_rm.npy'))
+fpr_segmentation_no_ft = np.load(os.path.join(curves_dir, 'fpr_segmentation_triple_wind_with_std_rm.npy'))
+tpr_segmentation_no_ft = np.load(os.path.join(curves_dir, 'tpr_segmentation_triple_wind_with_std_rm.npy'))
 
 # Calculate AUC for Precision-Recall curves
 auc_pr_classification_ft = auc(recall_classification_ft, precision_classification_ft)

--- a/paths.py
+++ b/paths.py
@@ -1,0 +1,7 @@
+import os
+
+# Default paths for running in Google Colab
+RAW_DATA_AND_LABELS_DIR = os.environ.get('RAW_DATA_AND_LABELS_DIR', '/content/data_and_labels')
+PROCESSED_DATA_DIR = os.environ.get('PROCESSED_DATA_DIR', '/content/processed_data')
+OUTPUT_DIR = os.environ.get('OUTPUT_DIR', '/content/output')
+CHECKPOINT_PATH = os.environ.get('CHECKPOINT_PATH', '/content/checkpoints/checkpoint.pt')

--- a/read_data.py
+++ b/read_data.py
@@ -4,22 +4,23 @@ import numpy as np
 import pandas as pd
 import csv
 import ipdb
+from paths import RAW_DATA_AND_LABELS_DIR, PROCESSED_DATA_DIR
 
-SYNC_FILE_NAME = '/home/dafnas1/datasets/hd_dataset/lab_geneactive/sync_params.xlsx'
-WS_SYNC_FILE_NAME = '/home/dafnas1/datasets/hd_dataset/lab_geneactive/ws_sync_params.xlsx'
+SYNC_FILE_NAME = os.path.join(RAW_DATA_AND_LABELS_DIR, 'sync_params.xlsx')
+WS_SYNC_FILE_NAME = os.path.join(RAW_DATA_AND_LABELS_DIR, 'ws_sync_params.xlsx')
 KEY_COLUMN = 'video name'
 VALUE_COLUMNS = ['video 2m walk start time (seconds)', 'sensor 2m walk start time (seconds)','FPS']
 SYNC_SHEET_NAME = 'Sheet1'
 
-ACC_DATA_DIR = '/home/dafnas1/datasets/hd_dataset/lab_geneactive/acc_data/right_wrist'
-WS_ACC_DATA_DIR = '/home/dafnas1/datasets/hd_dataset/lab_geneactive/acc_data/WS_acc_files'
-LABEL_DATA_DIR = '/home/dafnas1/datasets/hd_dataset/lab_geneactive/labeled data'
-OPAL_LABEL_DATA_DIR = '/home/dafnas1/datasets/hd_dataset/lab_geneactive/labeled data/WS_label_files'
-TARGET_DIR = '/home/dafnas1/datasets/hd_dataset/lab_geneactive/synced_labeled_data_walking_non_walking'
-DAILY_DATA_DIR = '/mlwell-data2/dafna/daily_living_for_ssl_gait_detection_paper/HC'
-DAILY_TARGET_DIR = '/mlwell-data2/dafna/daily_living_data_array/HC'
-PACE_DAILY_DATA_DIR ='/mlwell-data2/dafna/PACEHD_for_ssl_paper'
-PACE_DAILY_TARGET_DIR ='/mlwell-data2/dafna/daily_living_data_array/PACE'
+ACC_DATA_DIR = os.path.join(RAW_DATA_AND_LABELS_DIR, 'acc_data/right_wrist')
+WS_ACC_DATA_DIR = os.path.join(RAW_DATA_AND_LABELS_DIR, 'acc_data/WS_acc_files')
+LABEL_DATA_DIR = os.path.join(RAW_DATA_AND_LABELS_DIR, 'labeled data')
+OPAL_LABEL_DATA_DIR = os.path.join(RAW_DATA_AND_LABELS_DIR, 'labeled data/WS_label_files')
+TARGET_DIR = RAW_DATA_AND_LABELS_DIR
+DAILY_DATA_DIR = os.path.join(PROCESSED_DATA_DIR, 'daily_living_for_ssl_gait_detection_paper/HC')
+DAILY_TARGET_DIR = os.path.join(PROCESSED_DATA_DIR, 'HC')
+PACE_DAILY_DATA_DIR = os.path.join(PROCESSED_DATA_DIR, 'PACEHD_for_ssl_paper')
+PACE_DAILY_TARGET_DIR = os.path.join(PROCESSED_DATA_DIR, 'PACE')
 ACC_SAMPLE_RATE = 100 # Hz
 #LABEL_SAMPLE_RATE = 59.94005994005994 # for movies from TC center 60 FPS
 missing_labels = []

--- a/read_timestamps.py
+++ b/read_timestamps.py
@@ -2,9 +2,10 @@ import os
 import pandas as pd
 from datetime import datetime
 import ipdb
+from paths import PROCESSED_DATA_DIR
 
 # Directory containing the CSV files
-directory = '/mlwell-data2/dafna/PACEHD_for_ssl_paper'
+directory = os.path.join(PROCESSED_DATA_DIR, 'PACEHD_for_ssl_paper')
 
 # Output text file
 output_file = 'PACE_start_times.txt'

--- a/ssl_boosting.py
+++ b/ssl_boosting.py
@@ -8,6 +8,7 @@ from starboost import BoostingClassifier
 import os
 import ipdb
 import wandb
+from paths import OUTPUT_DIR as BASE_OUTPUT_DIR, PROCESSED_DATA_DIR
 from sklearn import metrics
 import matplotlib.pyplot as plt
 import seaborn as sns
@@ -27,8 +28,7 @@ dataset_hd = 'iwear' # pace or iwear
 #FILE_PREFIX = 'classification_test' #segmentation_val' or'segmentation_without_edges_overlap' or 'segmentation_triple_wind_no_shift'
 GAIT_ONLY = True
 gait_only_prefix = "_gait_only" if GAIT_ONLY else ""
-OUTPUT_DIR = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files'
-#UTPUT_DIR = '/mlwell-data2/dafna/ssl_gait_detection/model_outputs/output_files'
+OUTPUT_DIR = os.path.join(BASE_OUTPUT_DIR, 'output_files')
 
 TRAIN_MODE = False
 EVAL_MODE = True
@@ -36,113 +36,174 @@ ILLUSTRATE_RESULTS = False
 ## for in lab
 if data_type == 'in_lab':
     if COHORT == 'hd' and training_cohort != 'hd_and_pd_train' :
-        input_data_dir = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/data_ready' # /mlwell-data2/dafna/in_lab_data_array or /home/dafnas1/my_repo/hd_gait_detection_with_SSL/data_ready
+        input_data_dir = PROCESSED_DATA_DIR  # in-lab HD data
         INP_PREFIX = 'segmentation_triple_wind_no_shift' #or 'check_labels'
         #segmentation_labels' or'segmentation_without_edges_overlap' or 'segmentation_triple_wind_no_shift' or 'classification_test' or 'daily_living_classification_full_files' or 'classification_hc'
         #as in the output file of preditions
         OUT_PREFIX = 'segmentation_triple_wind_no_shift_final_8_4_24' #'classification_test_final' or 'segmentation_triple_wind_no_shift_final_8_4_24'
     if COHORT == 'hc' and training_cohort != 'hd_and_pd_train' :
-        input_data_dir = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/data_ready' # or /mlwell-data2/dafna/in_lab_data_array
+        input_data_dir = PROCESSED_DATA_DIR
         INP_PREFIX = 'classification_hc'
         #as in the output file of preditions
         OUT_PREFIX = 'classification_7_4_24_chorea_0_only_gait_only_hc' 
     if COHORT == 'pd_owly' and model_type=='classification':
-        input_data_dir = '/mlwell-data2/dafna/daily_living_data_array/data_ready'
+        input_data_dir = PROCESSED_DATA_DIR
         INP_PREFIX = 'classification_with_std_rm'
         OUT_PREFIX = 'classification_with_std_rm_with_fine_tuning'
-    if COHORT == 'pd_owly' and model_type=='segmentation': 
-        input_data_dir = '/mlwell-data2/dafna/daily_living_data_array/data_ready'
+    if COHORT == 'pd_owly' and model_type=='segmentation':
+        input_data_dir = PROCESSED_DATA_DIR
         INP_PREFIX = 'segmentation_triple_wind_with_std_rm'
         OUT_PREFIX = 'segmentation_triple_wind_with_std_rm_with_fine_tuning'
     if COHORT == 'hd_and_pd_train' and model_type=='classification':
         COHORT_1 = 'hd'
         COHORT_2 = 'pd_owly'
-        input_data_dir_1 = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/data_ready' ## HD
+        input_data_dir_1 = PROCESSED_DATA_DIR  ## HD
         INP_PREFIX_1 = 'classification_test'
-        input_data_dir_2 = '/mlwell-data2/dafna/daily_living_data_array/data_ready' ##PD
+        input_data_dir_2 = PROCESSED_DATA_DIR  ## PD
         INP_PREFIX_2 = 'classification_with_std_rm'
         OUT_PREFIX = 'classifiction'
     if COHORT == 'hd_and_pd_train' and model_type=='segmentation':
         COHORT_1 = 'hd'
         COHORT_2 = 'pd_owly'
-        input_data_dir_1 = '/mlwell-data2/dafna/in_lab_data_array' ## HD
+        input_data_dir_1 = PROCESSED_DATA_DIR  ## HD
         INP_PREFIX_1 = 'segmentation_triple_wind_no_shift'
-        input_data_dir_2 = '/mlwell-data2/dafna/daily_living_data_array/data_ready' ##PD
+        input_data_dir_2 = PROCESSED_DATA_DIR  ## PD
         INP_PREFIX_2 = 'segmentation_triple_wind_with_std_rm'
         OUT_PREFIX = 'segmentation_triple_wind'
     if model_type == 'vanila':
-        EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hc_only_boosting_classification_7_4_24_chorea_0_only_gait_only.pt'
+        EXTERNAL_MODEL_FILE = os.path.join(
+            BASE_OUTPUT_DIR,
+            'output_files',
+            'multiclass_weights_hc_only_boosting_classification_7_4_24_chorea_0_only_gait_only.pt'
+        )
     else:
         EXTERNAL_MODEL_FILE = None
 ## for daily living
 if data_type == 'daily_living':
-    input_data_dir = '/mlwell-data2/dafna/daily_living_data_array/data_ready'
+    input_data_dir = PROCESSED_DATA_DIR
     if dataset_hd == 'iwear':
         if COHORT == 'hc' and model_type=='segmentation':
             INP_PREFIX = 'daily_living_segmentation_triple_wind_full_files_no_std'
             OUT_PREFIX = 'daily_living_seg_triple_wind_no_std'
-            EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hc_only_boosting_segmentation_triple_wind_hc_7_4_24_chorea_0_only_gait_only.pt'
+            EXTERNAL_MODEL_FILE = os.path.join(
+                BASE_OUTPUT_DIR,
+                'output_files',
+                'multiclass_weights_hc_only_boosting_segmentation_triple_wind_hc_7_4_24_chorea_0_only_gait_only.pt'
+            )
         if COHORT == 'hc' and model_type=='classification':
             INP_PREFIX = 'daily_living_classification_full_files_no_std'
             OUT_PREFIX = 'daily_living_classification_no_std'
-            EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hc_only_boosting_classification_7_4_24_chorea_0_only_gait_only.pt'
+            EXTERNAL_MODEL_FILE = os.path.join(
+                BASE_OUTPUT_DIR,
+                'output_files',
+                'multiclass_weights_hc_only_boosting_classification_7_4_24_chorea_0_only_gait_only.pt'
+            )
     if COHORT == 'hd' and model_type=='segmentation': 
         if dataset_hd == 'iwear':
             INP_PREFIX = 'daily_living_segmentation_triple_wind_full_files_no_std'
             OUT_PREFIX = 'daily_living_seg_triple_wind_no_std'
-            EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_only_boosting_segmentation_triple_wind_no_shift_final_8_4_24_gait_only.pt'
+            EXTERNAL_MODEL_FILE = os.path.join(
+                BASE_OUTPUT_DIR,
+                'output_files',
+                'multiclass_weights_hd_only_boosting_segmentation_triple_wind_no_shift_final_8_4_24_gait_only.pt'
+            )
         elif dataset_hd == 'pace':
             INP_PREFIX = 'segmentation_triple_wind_pace'
             OUT_PREFIX = 'segmentation_triple_wind_daily_pace'
-            EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_only_boosting_segmentation_triple_wind_no_shift_final_8_4_24_gait_only.pt'
+            EXTERNAL_MODEL_FILE = os.path.join(
+                BASE_OUTPUT_DIR,
+                'output_files',
+                'multiclass_weights_hd_only_boosting_segmentation_triple_wind_no_shift_final_8_4_24_gait_only.pt'
+            )
     if COHORT == 'hd' and model_type=='classification': 
         if dataset_hd == 'iwear':
             INP_PREFIX = 'daily_living_classification_full_files_no_std'
             OUT_PREFIX = 'daily_living_classification_no_std'
-            EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_only_boosting_classification_test_final_gait_only.pt'
+            EXTERNAL_MODEL_FILE = os.path.join(
+                BASE_OUTPUT_DIR,
+                'output_files',
+                'multiclass_weights_hd_only_boosting_classification_test_final_gait_only.pt'
+            )
         elif dataset_hd== 'pace':
             INP_PREFIX = 'classification_daily_pace'
             OUT_PREFIX = 'classification_daily_pace'
-            EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_only_boosting_classification_test_final_gait_only.pt'
+            EXTERNAL_MODEL_FILE = os.path.join(
+                BASE_OUTPUT_DIR,
+                'output_files',
+                'multiclass_weights_hd_only_boosting_classification_test_final_gait_only.pt'
+            )
     if COHORT == 'pd_owly' and model_type=='segmentation': 
         INP_PREFIX = 'segmentation_triple_wind_with_std_rm'
         OUT_PREFIX = 'segmentation_triple_wind_with_std_rm'
-        EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_only_boosting_segmentation_triple_wind_no_shift_final_8_4_24_gait_only.pt'
+        EXTERNAL_MODEL_FILE = os.path.join(
+            BASE_OUTPUT_DIR,
+            'output_files',
+            'multiclass_weights_hd_only_boosting_segmentation_triple_wind_no_shift_final_8_4_24_gait_only.pt'
+        )
     if COHORT == 'pd_owly' and model_type=='classification':
         INP_PREFIX = 'classification_with_std_rm'
         OUT_PREFIX = 'classification_with_std_rm'
-        EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_only_boosting_classification_test_final_gait_only.pt' 
+        EXTERNAL_MODEL_FILE = os.path.join(
+            BASE_OUTPUT_DIR,
+            'output_files',
+            'multiclass_weights_hd_only_boosting_classification_test_final_gait_only.pt'
+        )
     if COHORT == 'hd' and model_type=='vanila':
         # test the hc model on hd data
-        input_data_dir = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/data_ready'
+        input_data_dir = PROCESSED_DATA_DIR
         INP_PREFIX = 'classification_test' 
         OUT_PREFIX = 'vanila_hc_model_on_hd' 
-        EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hc_only_boosting_classification_7_4_24_chorea_0_only_gait_only.pt'
+        EXTERNAL_MODEL_FILE = os.path.join(
+            BASE_OUTPUT_DIR,
+            'output_files',
+            'multiclass_weights_hc_only_boosting_classification_7_4_24_chorea_0_only_gait_only.pt'
+        )
     if training_cohort == 'hd_and_pd_train':
         if COHORT == 'hd' and model_type=='classification':
             # test the combine hd+pd model on hd data
-            input_data_dir = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/data_ready'
+            input_data_dir = PROCESSED_DATA_DIR
             INP_PREFIX = 'classification_test' 
             OUT_PREFIX = 'classification_combined_hd_and_pd_in_lab' 
-            EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_and_pd_train_only_boosting_classifiction_gait_only.pt'
+            EXTERNAL_MODEL_FILE = os.path.join(
+                BASE_OUTPUT_DIR,
+                'output_files',
+                'multiclass_weights_hd_and_pd_train_only_boosting_classifiction_gait_only.pt'
+            )
         if COHORT == 'hd' and model_type=='segmentation':
-            input_data_dir = '/mlwell-data2/dafna/in_lab_data_array'
+            input_data_dir = PROCESSED_DATA_DIR
             INP_PREFIX = 'segmentation_triple_wind_no_shift'
             OUT_PREFIX = 'segmentation_combined_hd_and_pd_in_lab'
-            EXTERNAL_MODEL_FILE = '/mlwell-data2/dafna/ssl_gait_detection/model_outputs/output_files/multiclass_weights_hd_and_pd_train_only_boosting_segmentation_triple_wind_gait_only.pt'
+            EXTERNAL_MODEL_FILE = os.path.join(
+                BASE_OUTPUT_DIR,
+                'output_files',
+                'multiclass_weights_hd_and_pd_train_only_boosting_segmentation_triple_wind_gait_only.pt'
+            )
         if COHORT == 'pd_owly' and model_type=='classification':
-            input_data_dir = '/mlwell-data2/dafna/daily_living_data_array/data_ready'
+            input_data_dir = PROCESSED_DATA_DIR
             INP_PREFIX = 'classification_with_std_rm'
             OUT_PREFIX = 'classification_combined_hd_and_pd_in_lab'
-            EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_and_pd_train_only_boosting_classifiction_gait_only.pt'
-        if COHORT == 'pd_owly' and model_type=='segmentation': 
-            input_data_dir = '/mlwell-data2/dafna/daily_living_data_array/data_ready'
+            EXTERNAL_MODEL_FILE = os.path.join(
+                BASE_OUTPUT_DIR,
+                'output_files',
+                'multiclass_weights_hd_and_pd_train_only_boosting_classifiction_gait_only.pt'
+            )
+        if COHORT == 'pd_owly' and model_type=='segmentation':
+            input_data_dir = PROCESSED_DATA_DIR
             INP_PREFIX = 'segmentation_triple_wind_with_std_rm'
             OUT_PREFIX = 'segmentation_triple_wind_combined_hd_and_pd_in_lab'
-            EXTERNAL_MODEL_FILE = '/mlwell-data2/dafna/ssl_gait_detection/model_outputs/output_files/multiclass_weights_hd_and_pd_train_only_boosting_segmentation_triple_wind_gait_only.pt'
+            EXTERNAL_MODEL_FILE = os.path.join(
+                BASE_OUTPUT_DIR,
+                'output_files',
+                'multiclass_weights_hd_and_pd_train_only_boosting_segmentation_triple_wind_gait_only.pt'
+            )
         
 
-VIZUALIZE_DIR = f'/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/results_visualization/boosting/{OUT_PREFIX}'+gait_only_prefix+'_'+ COHORT
+# Directory for visualization outputs
+VIZUALIZE_DIR = os.path.join(
+    BASE_OUTPUT_DIR,
+    'results_visualization/boosting',
+    f'{OUT_PREFIX}'+gait_only_prefix+'_'+COHORT
+)
 #VIZUALIZE_DIR = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/results_visualization/boosting/classification_7_4_24_chorea_0_only_gait_only_hc'
 
 # !!!!remember to change segmentation/classifiction also in sslmodel.py !!!!!
@@ -582,10 +643,17 @@ def main():
             false_class_video_time = win_video_time[mismatch_indices]
             false_class_subject = win_subjects[0][mismatch_indices]
             
-            np.savez('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/false_gait_classification_video_start_time_andsubjects.npz',
-            false_class_video_time=false_class_video_time,false_class_subject=false_class_subject)
+            np.savez(
+                os.path.join(BASE_OUTPUT_DIR, 'false_gait_classification_video_start_time_andsubjects.npz'),
+                false_class_video_time=false_class_video_time,
+                false_class_subject=false_class_subject
+            )
         #### compare classification and seg windows DEBUGG#####
-        class_false_gait = dict(np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/false_gait_classification_video_start_time_andsubjects.npz'))
+        class_false_gait = dict(
+            np.load(
+                os.path.join(BASE_OUTPUT_DIR, 'false_gait_classification_video_start_time_andsubjects.npz')
+            )
+        )
         class_false_gait_video = class_false_gait['false_class_video_time'].flatten()
         class_false_gait_subject = class_false_gait['false_class_subject'].flatten()
         for video, subject in zip(class_false_gait_video, class_false_gait_subject):
@@ -636,7 +704,7 @@ def main():
                                              chorea_labels=chorea_labels_all_folds[0],
                                              analysis_type='per_pixel')
         
-        scores_file = os.path.join('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs','scores.json')
+        scores_file = os.path.join(BASE_OUTPUT_DIR, 'scores.json')
 
         # New model configuration name
         new_config_name = OUT_PREFIX+gait_only_prefix+'_'+COHORT
@@ -1009,10 +1077,13 @@ def add_noise_to_window(window, noise_std):
 def plot_curves(labels, probs):
     fpr, tpr, _ = metrics.roc_curve(labels, probs)
     precision, recall, _ = metrics.precision_recall_curve(labels, probs)
-    np.save(os.path.join('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves',f'fpr_{OUT_PREFIX}.npy'),fpr)
-    np.save(os.path.join('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves',f'tpr_{OUT_PREFIX}.npy'),tpr)
-    np.save(os.path.join('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves',f'precision_{OUT_PREFIX}.npy'),precision)
-    np.save(os.path.join('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/final_graphs/pd_curves',f'recall_{OUT_PREFIX}.npy'),recall)
+    curves_dir = os.path.join(BASE_OUTPUT_DIR, 'final_graphs/pd_curves')
+    if not os.path.exists(curves_dir):
+        os.makedirs(curves_dir)
+    np.save(os.path.join(curves_dir, f'fpr_{OUT_PREFIX}.npy'), fpr)
+    np.save(os.path.join(curves_dir, f'tpr_{OUT_PREFIX}.npy'), tpr)
+    np.save(os.path.join(curves_dir, f'precision_{OUT_PREFIX}.npy'), precision)
+    np.save(os.path.join(curves_dir, f'recall_{OUT_PREFIX}.npy'), recall)
 
     ipdb.set_trace()
     plt.figure()

--- a/sslmodel.py
+++ b/sslmodel.py
@@ -124,6 +124,8 @@ class NormalDataset(Dataset):
         return sample, y, pid
 
 
+from paths import CHECKPOINT_PATH
+
 class EarlyStopping:
     """Early stops the training if validation loss
     doesn't improve after a given patience."""
@@ -133,7 +135,7 @@ class EarlyStopping:
             patience=15,
             verbose=False,
             delta=0,
-            path="/mlwell-data2/dafna/ssl_gait_detection/model_outputs/checkpoints/checkpoint.pt",#"checkpoint.pt",
+            path=CHECKPOINT_PATH,  # "checkpoint.pt",
             trace_func=print,
     ):
         """

--- a/train_hd_ssl.py
+++ b/train_hd_ssl.py
@@ -3,6 +3,7 @@ import evaluation_func
 import numpy as np
 import os
 import torch
+from paths import RAW_DATA_AND_LABELS_DIR, PROCESSED_DATA_DIR, OUTPUT_DIR
 from sklearn import metrics
 from scipy.special import softmax
 import seaborn as sns
@@ -94,14 +95,10 @@ args = parser.parse_args()
 
 
 VISUALIZE_ACC_VS_PRED_WIN = False
-RAW_DATA_AND_LABELS_DIR = '/home/dafnas1/datasets/hd_dataset/lab_geneactive/synced_labeled_data_walking_non_walking'
-#RAW_DATA_AND_LABELS_DIR = '/mlwell-data2/dafna/daily_living_data_array/HC'
-#RAW_DATA_AND_LABELS_DIR = '/mlwell-data2/dafna/PD_data_and_labels/Data'
-#PD_RAW_LABELS_DIR = '/mlwell-data2/dafna/PD_data_and_labels/labels'
-#RAW_DATA_AND_LABELS_DIR = '/mlwell-data2/dafna/daily_living_data_array/PACE'
-PROCESSED_DATA_DIR ='/mlwell-data2/dafna/daily_living_data_array/data_ready'
-OUTPUT_DIR = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs'
-VIZUALIZE_DIR = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/results_visualization/multiclass_hd_only/multiclass_separated_labels'
+VIZUALIZE_DIR = os.path.join(
+    OUTPUT_DIR,
+    'results_visualization/multiclass_hd_only/multiclass_separated_labels'
+)
 if args.cohort == 'pd_owly':
     SRC_SAMPLE_RATE = int(25) #hz
 else:
@@ -398,7 +395,7 @@ def main():
         #FILE_PREFIX = 'classification_test' #segmentation_val' or'segmentation_without_edges_overlap' or 'segmentation_triple_wind_no_shift'
         
         gait_only_prefix = "_gait_only" if args.gait_only else ""
-        OUTPUT_DIR = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files'
+        OUTPUT_DIR = os.path.join(OUTPUT_DIR, 'output_files')
         #UTPUT_DIR = '/mlwell-data2/dafna/ssl_gait_detection/model_outputs/output_files'
 
         
@@ -406,75 +403,119 @@ def main():
         ## for in lab
         if args.data_type == 'in_lab':
             if args.cohort == 'hd':
-                input_data_dir = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/data_ready' # /mlwell-data2/dafna/in_lab_data_array or /home/dafnas1/my_repo/hd_gait_detection_with_SSL/data_ready
+                input_data_dir = PROCESSED_DATA_DIR  # in-lab HD data
                 INP_PREFIX = 'segmentation_triple_wind_no_shift' #or 'check_labels'
                 #segmentation_labels' or'segmentation_without_edges_overlap' or 'segmentation_triple_wind_no_shift' or 'classification_test' or 'daily_living_classification_full_files' or 'classification_hc'
                 #as in the output file of preditions
                 OUT_PREFIX = 'segmentation_triple_wind_no_shift_final_8_4_24' #'classification_test_final' or 'segmentation_triple_wind_no_shift_final_8_4_24'
             if args.cohort == 'hc':
-                input_data_dir = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/data_ready' # or /mlwell-data2/dafna/in_lab_data_array
+                input_data_dir = PROCESSED_DATA_DIR
                 INP_PREFIX = 'classification_hc'
                 #as in the output file of preditions
                 OUT_PREFIX = 'classification_7_4_24_chorea_0_only_gait_only_hc' 
             if args.cohort == 'pd_owly' and args.model_type=='classification':
-                input_data_dir = '/mlwell-data2/dafna/daily_living_data_array/data_ready'
+                input_data_dir = PROCESSED_DATA_DIR
                 INP_PREFIX = 'classification_with_std_rm'
                 OUT_PREFIX = 'classification_with_std_rm_with_fine_tuning'
-            if args.cohort == 'pd_owly' and args.model_type=='segmentation': 
-                input_data_dir = '/mlwell-data2/dafna/daily_living_data_array/data_ready'
+            if args.cohort == 'pd_owly' and args.model_type=='segmentation':
+                input_data_dir = PROCESSED_DATA_DIR
                 INP_PREFIX = 'segmentation_triple_wind_with_std_rm'
                 OUT_PREFIX = 'segmentation_triple_wind_with_std_rm_with_fine_tuning'
             if args.model_type == 'vanila':
-                EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hc_only_boosting_classification_7_4_24_chorea_0_only_gait_only.pt'
+                EXTERNAL_MODEL_FILE = os.path.join(
+                    OUTPUT_DIR,
+                    'output_files',
+                    'multiclass_weights_hc_only_boosting_classification_7_4_24_chorea_0_only_gait_only.pt'
+                )
             else:
                 EXTERNAL_MODEL_FILE = None
         ## for daily living
         if args.data_type == 'daily_living':
-            input_data_dir = '/mlwell-data2/dafna/daily_living_data_array/data_ready'
+            input_data_dir = PROCESSED_DATA_DIR
             if args.dataset_hd == 'iwear':
                 if args.cohort == 'hc' and args.model_type=='segmentation':
                     INP_PREFIX = 'daily_living_segmentation_triple_wind_full_files_no_std'
                     OUT_PREFIX = 'daily_living_seg_triple_wind_no_std'
-                    EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hc_only_boosting_segmentation_triple_wind_hc_7_4_24_chorea_0_only_gait_only.pt'
+                    EXTERNAL_MODEL_FILE = os.path.join(
+                        OUTPUT_DIR,
+                        'output_files',
+                        'multiclass_weights_hc_only_boosting_segmentation_triple_wind_hc_7_4_24_chorea_0_only_gait_only.pt'
+                    )
                 if args.cohort == 'hc' and args.model_type=='classification':
                     INP_PREFIX = 'daily_living_classification_full_files_no_std'
                     OUT_PREFIX = 'daily_living_classification_no_std'
-                    EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hc_only_boosting_classification_7_4_24_chorea_0_only_gait_only.pt'
+                    EXTERNAL_MODEL_FILE = os.path.join(
+                        OUTPUT_DIR,
+                        'output_files',
+                        'multiclass_weights_hc_only_boosting_classification_7_4_24_chorea_0_only_gait_only.pt'
+                    )
             if args.cohort == 'hd' and args.model_type=='segmentation': 
                 if args.dataset_hd == 'iwear':
                     INP_PREFIX = 'daily_living_segmentation_triple_wind_full_files_no_std'
                     OUT_PREFIX = 'daily_living_seg_triple_wind_no_std'
-                    EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_only_boosting_segmentation_triple_wind_no_shift_final_8_4_24_gait_only.pt'
+                    EXTERNAL_MODEL_FILE = os.path.join(
+                        OUTPUT_DIR,
+                        'output_files',
+                        'multiclass_weights_hd_only_boosting_segmentation_triple_wind_no_shift_final_8_4_24_gait_only.pt'
+                    )
                 elif args.dataset_hd == 'pace':
                     INP_PREFIX = 'segmentation_triple_wind_pace'
                     OUT_PREFIX = 'segmentation_triple_wind_daily_pace'
-                    EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_only_boosting_segmentation_triple_wind_no_shift_final_8_4_24_gait_only.pt'
+                    EXTERNAL_MODEL_FILE = os.path.join(
+                        OUTPUT_DIR,
+                        'output_files',
+                        'multiclass_weights_hd_only_boosting_segmentation_triple_wind_no_shift_final_8_4_24_gait_only.pt'
+                    )
             if args.cohort == 'hd' and args.model_type=='classification': 
                 if args.dataset_hd == 'iwear':
                     INP_PREFIX = 'daily_living_classification_full_files_no_std'
                     OUT_PREFIX = 'daily_living_classification_no_std'
-                    EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_only_boosting_classification_test_final_gait_only.pt'
+                    EXTERNAL_MODEL_FILE = os.path.join(
+                        OUTPUT_DIR,
+                        'output_files',
+                        'multiclass_weights_hd_only_boosting_classification_test_final_gait_only.pt'
+                    )
                 elif args.dataset_hd== 'pace':
                     INP_PREFIX = 'classification_daily_pace'
                     OUT_PREFIX = 'classification_daily_pace'
-                    EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_only_boosting_classification_test_final_gait_only.pt'
+                    EXTERNAL_MODEL_FILE = os.path.join(
+                        OUTPUT_DIR,
+                        'output_files',
+                        'multiclass_weights_hd_only_boosting_classification_test_final_gait_only.pt'
+                    )
             if args.cohort == 'pd_owly' and args.model_type=='segmentation': 
                 INP_PREFIX = 'segmentation_triple_wind_with_std_rm'
                 OUT_PREFIX = 'segmentation_triple_wind_with_std_rm'
-                EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_only_boosting_segmentation_triple_wind_no_shift_final_8_4_24_gait_only.pt'
+                EXTERNAL_MODEL_FILE = os.path.join(
+                    OUTPUT_DIR,
+                    'output_files',
+                    'multiclass_weights_hd_only_boosting_segmentation_triple_wind_no_shift_final_8_4_24_gait_only.pt'
+                )
             if args.cohort == 'pd_owly' and args.model_type=='classification':
                 INP_PREFIX = 'classification_with_std_rm'
                 OUT_PREFIX = 'classification_with_std_rm'
-                EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hd_only_boosting_classification_test_final_gait_only.pt' 
+                EXTERNAL_MODEL_FILE = os.path.join(
+                    OUTPUT_DIR,
+                    'output_files',
+                    'multiclass_weights_hd_only_boosting_classification_test_final_gait_only.pt'
+                )
             if args.cohort == 'hd' and args.model_type=='vanila':
                 # test the hc model on hd data
-                input_data_dir = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/data_ready'
+                input_data_dir = PROCESSED_DATA_DIR
                 INP_PREFIX = 'classification_test' 
                 OUT_PREFIX = 'vanila_hc_model_on_hd' 
-                EXTERNAL_MODEL_FILE = '/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/output_files/multiclass_weights_hc_only_boosting_classification_7_4_24_chorea_0_only_gait_only.pt'
+                EXTERNAL_MODEL_FILE = os.path.join(
+                    OUTPUT_DIR,
+                    'output_files',
+                    'multiclass_weights_hc_only_boosting_classification_7_4_24_chorea_0_only_gait_only.pt'
+                )
                 
 
-        VIZUALIZE_DIR = f'/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs/results_visualization/boosting/{OUT_PREFIX}'+gait_only_prefix+'_'+ args.cohort
+        VIZUALIZE_DIR = os.path.join(
+            OUTPUT_DIR,
+            'results_visualization/boosting',
+            f'{OUT_PREFIX}'+gait_only_prefix+'_'+args.cohort
+        )
         n_estimators = 0
         learning_rate = 0.5
 
@@ -608,13 +649,15 @@ def main():
             valid_chorea_all_folds = np.concatenate(valid_chorea_all_folds)
 
             if True:
-            evaluation_func.generate_confusion_matrix_per_chorea_lvl(gait_predictions_all_folds, 
-                                                    gait_labels_all_folds, 
-                                                    chorea_predictions_all_folds, 
-                                                    chorea_labels_all_folds, 
-                                                    valid_chorea_all_folds, 
-                                                    valid_gait_all_folds,
-                                                    fold_index='all')
+                evaluation_func.generate_confusion_matrix_per_chorea_lvl(
+                    gait_predictions_all_folds,
+                    gait_labels_all_folds,
+                    chorea_predictions_all_folds,
+                    chorea_labels_all_folds,
+                    valid_chorea_all_folds,
+                    valid_gait_all_folds,
+                    fold_index='all'
+                )
         
 
             np.savez(os.path.join(OUTPUT_DIR, f'multiclass_separated_labels_predictions_and_logits_with_true_labels_and_subjects_{COHORT}_only_boosting_{OUT_PREFIX}'+gait_only_prefix+'.npz'),
@@ -666,10 +709,15 @@ def main():
                 false_class_video_time = win_video_time[mismatch_indices]
                 false_class_subject = win_subjects[0][mismatch_indices]
                 
-                np.savez('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/false_gait_classification_video_start_time_andsubjects.npz',
-                false_class_video_time=false_class_video_time,false_class_subject=false_class_subject)
+                np.savez(
+                    os.path.join(OUTPUT_DIR, 'false_gait_classification_video_start_time_andsubjects.npz'),
+                    false_class_video_time=false_class_video_time,
+                    false_class_subject=false_class_subject
+                )
             #### compare classification and seg windows DEBUGG#####
-            class_false_gait = dict(np.load('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/false_gait_classification_video_start_time_andsubjects.npz'))
+            class_false_gait = dict(
+                np.load(os.path.join(OUTPUT_DIR, 'false_gait_classification_video_start_time_andsubjects.npz'))
+            )
             class_false_gait_video = class_false_gait['false_class_video_time'].flatten()
             class_false_gait_subject = class_false_gait['false_class_subject'].flatten()
             for video, subject in zip(class_false_gait_video, class_false_gait_subject):
@@ -720,7 +768,7 @@ def main():
                                                 chorea_labels=chorea_labels_all_folds[0],
                                                 analysis_type='per_pixel')
             
-            scores_file = os.path.join('/home/dafnas1/my_repo/hd_gait_detection_with_SSL/model_outputs','scores.json')
+            scores_file = os.path.join(OUTPUT_DIR, 'scores.json')
 
             # New model configuration name
             new_config_name = OUT_PREFIX+gait_only_prefix+'_'+COHORT


### PR DESCRIPTION
## Summary
- add `paths.py` with default directories and environment overrides
- refactor scripts to use the new path settings instead of hardcoded paths
- update README with instructions for customizing directories

## Testing
- `python -m py_compile paths.py main.py train_hd_ssl.py ssl_boosting.py sslmodel.py daily_living_results_eval.py evaluation_func.py read_data.py read_timestamps.py model_outputs/final_graphs/json_visualization.py model_outputs/final_graphs/pd_curves/combine_curves.py generate_scatter_compare_hd_hc.py`

------
https://chatgpt.com/codex/tasks/task_e_684c4792a22c83279b6f0e599e5a7b79